### PR TITLE
Handle multiple Stop calls in detector

### DIFF
--- a/internal/detector/detector.go
+++ b/internal/detector/detector.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"sync"
 	"time"
 
 	"aiops-platform/internal/types"
@@ -12,10 +13,11 @@ import (
 
 // Detector представляет основной детектор аномалий
 type Detector struct {
-	config     *types.Config
-	server     *http.Server
-	processors []Processor
-	shutdown   chan struct{}
+	config       *types.Config
+	server       *http.Server
+	processors   []Processor
+	shutdown     chan struct{}
+	shutdownOnce sync.Once
 }
 
 // Processor интерфейс для обработчиков аномалий
@@ -107,7 +109,9 @@ func (d *Detector) Stop(ctx context.Context) error {
 		return fmt.Errorf("failed to shutdown HTTP server: %w", err)
 	}
 
-	close(d.shutdown)
+	d.shutdownOnce.Do(func() {
+		close(d.shutdown)
+	})
 	return nil
 }
 

--- a/internal/detector/detector_test.go
+++ b/internal/detector/detector_test.go
@@ -1,0 +1,29 @@
+package detector
+
+import (
+	"context"
+	"testing"
+
+	"aiops-platform/internal/types"
+)
+
+func TestStopTwiceDoesNotPanic(t *testing.T) {
+	cfg := &types.Config{
+		Server: types.ServerConfig{
+			Host: "127.0.0.1",
+			Port: 0,
+		},
+	}
+	d, err := New(cfg)
+	if err != nil {
+		t.Fatalf("failed to create detector: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := d.Stop(ctx); err != nil {
+		t.Fatalf("first stop returned error: %v", err)
+	}
+	if err := d.Stop(ctx); err != nil {
+		t.Fatalf("second stop returned error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- make Detector.Stop idempotent by using sync.Once
- add unit test calling Stop twice

## Testing
- `go test ./...` *(fails: gopkg.in/yaml.v3 fetch blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6853ef79183c833384819295b637246b